### PR TITLE
Neural Network View Mode

### DIFF
--- a/NeuralNetwork/NeuralNetwork.py
+++ b/NeuralNetwork/NeuralNetwork.py
@@ -17,22 +17,26 @@ testloader = torch.utils.data.DataLoader(testset, batch_size=3, shuffle=False, n
 
 iterator = iter(testloader)
 
-print('Showing ground truth')
-groundTruth = iterator.next()
-imshow(groundTruth[0][0])
-imshow(groundTruth[0][1])
-imshow(groundTruth[0][2])
+print('Showing splats')
+splats = iterator.next()
+imshow(splats[0][0])
+imshow(splats[0][1])
+imshow(splats[0][2])
 
-print('Showing input')
-input = iterator.next()
-imshow(input[0][0])
-imshow(input[0][1])
-imshow(input[0][2])
+print('Showing sparse points')
+sparsePoints = iterator.next()
+imshow(sparsePoints[0][0])
+imshow(sparsePoints[0][1])
+imshow(sparsePoints[0][2])
 
 # TESTING: Load neural network
 # Input and Output: 3 Channel Color (RGB), 1 Channel Depth
 model = torch.jit.load('./data/Pytorch_Jit_Model_Lucy.pt')
-print('Loaded pytorch model')
+model = model.to('cuda')
+print('Loaded model')
 
-# Evaluate model
-#output = model(input)
+# Evaluate model with random input
+input = torch.randn(1, 2, 1024, 1024)
+input = input.to('cuda')
+output = model(input)
+print('Done')

--- a/NeuralNetwork/NeuralNetwork.py
+++ b/NeuralNetwork/NeuralNetwork.py
@@ -5,43 +5,46 @@ import torchvision.transforms as transforms
 import matplotlib.pyplot as plt
 import numpy as np
 
-# Function to show an image
-def imshow(img):
-    npimg = img.detach().numpy()
-    npimg = np.transpose(npimg, axes=(1, 2, 0))
-    plt.imshow(npimg)
+# Function to show an image from a tensor
+def ShowImage(image):
+    npimage = image.detach().numpy()
+    npimage = np.transpose(npimage, axes=(1, 2, 0))
+    plt.imshow(npimage)
     plt.show()
 
+# Load rendered images from .png files in folders "/data/Testset/GroundTruth/" and "/data/Testset/Input/"
 testset = torchvision.datasets.ImageFolder(root='./data/Testset/', transform=torchvision.transforms.ToTensor())
 testloader = torch.utils.data.DataLoader(testset, batch_size=3, shuffle=False, num_workers=0)
 
+# Show the images by using an iterator
 iterator = iter(testloader)
 
 print('Showing splats')
 splats = iterator.next()
-imshow(splats[0][0])
-imshow(splats[0][1])
-imshow(splats[0][2])
+ShowImage(splats[0][0])
+#ShowImage(splats[0][1])
+#ShowImage(splats[0][2])
 
 print('Showing sparse points')
 sparsePoints = iterator.next()
-imshow(sparsePoints[0][0])
-imshow(sparsePoints[0][1])
-imshow(sparsePoints[0][2])
+ShowImage(sparsePoints[0][0])
+#ShowImage(sparsePoints[0][1])
+#ShowImage(sparsePoints[0][2])
 
-# TESTING: Load neural network
-# Input and Output: 3 Channel Color (RGB), 1 Channel Depth
+# Load and evaluate neural network
 model = torch.jit.load('./data/Pytorch_Jit_Model_Lucy.pt')
 model = model.cuda()
 print('Loaded model')
 
-# Evaluate model with random input
-input = torch.randn(1, 2, 1024, 1024)
+# Evaluate model with input from files
+# Input: 1 Channel Color (R, G or B), 1 Channel Depth
+# Output: 1 Channel Color, 1 Channel Depth, 1 Channel Visibility Mask
+input = sparsePoints[0].narrow(1, 0, 2)
 input = input.cuda()
 output = model(input)
 print('Evaluated model')
 
-# Show output image
+# Show output image from the neural network
 print('Showing output')
 output = output.cpu()
-imshow(output[0])
+ShowImage(output[0])

--- a/NeuralNetwork/NeuralNetwork.py
+++ b/NeuralNetwork/NeuralNetwork.py
@@ -7,7 +7,7 @@ import numpy as np
 
 # Function to show an image
 def imshow(img):
-    npimg = img.numpy()
+    npimg = img.detach().numpy()
     npimg = np.transpose(npimg, axes=(1, 2, 0))
     plt.imshow(npimg)
     plt.show()
@@ -32,11 +32,16 @@ imshow(sparsePoints[0][2])
 # TESTING: Load neural network
 # Input and Output: 3 Channel Color (RGB), 1 Channel Depth
 model = torch.jit.load('./data/Pytorch_Jit_Model_Lucy.pt')
-model = model.to('cuda')
+model = model.cuda()
 print('Loaded model')
 
 # Evaluate model with random input
 input = torch.randn(1, 2, 1024, 1024)
-input = input.to('cuda')
+input = input.cuda()
 output = model(input)
-print('Done')
+print('Evaluated model')
+
+# Show output image
+print('Showing output')
+output = output.cpu()
+imshow(output[0])

--- a/NeuralNetwork/NeuralNetwork.py
+++ b/NeuralNetwork/NeuralNetwork.py
@@ -5,28 +5,34 @@ import torchvision.transforms as transforms
 import matplotlib.pyplot as plt
 import numpy as np
 
-# Load and normalize CIFAR10 dataset
-transform = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))])
-trainset = torchvision.datasets.CIFAR10(root='./data', train=True, download=True, transform=transform)
-trainloader = torch.utils.data.DataLoader(trainset, batch_size=4, shuffle=True, num_workers=2)
-testset = torchvision.datasets.CIFAR10(root='./data', train=False, download=True, transform=transform)
-testloader = torch.utils.data.DataLoader(testset, batch_size=4, shuffle=False, num_workers=2)
-classes = ('plane', 'car', 'bird', 'cat', 'deer', 'dog', 'frog', 'horse', 'ship', 'truck')
-
 # Function to show an image
 def imshow(img):
-    img = img / 2 + 0.5     # unnormalize
     npimg = img.numpy()
+    npimg = np.transpose(npimg, axes=(1, 2, 0))
     plt.imshow(npimg)
     plt.show()
 
-# Show some random images with the labels
-for i in range(0, 5):
-    rnd = random.randrange(0, len(trainloader.dataset))
-    print(trainloader.dataset.classes[trainloader.dataset.targets[rnd]])
-    imshow(torch.from_numpy(trainloader.dataset.data[rnd]))
+testset = torchvision.datasets.ImageFolder(root='./data/Testset/', transform=torchvision.transforms.ToTensor())
+testloader = torch.utils.data.DataLoader(testset, batch_size=3, shuffle=False, num_workers=0)
+
+iterator = iter(testloader)
+
+print('Showing ground truth')
+groundTruth = iterator.next()
+imshow(groundTruth[0][0])
+imshow(groundTruth[0][1])
+imshow(groundTruth[0][2])
+
+print('Showing input')
+input = iterator.next()
+imshow(input[0][0])
+imshow(input[0][1])
+imshow(input[0][2])
 
 # TESTING: Load neural network
 # Input and Output: 3 Channel Color (RGB), 1 Channel Depth
 model = torch.jit.load('./data/Pytorch_Jit_Model_Lucy.pt')
 print('Loaded pytorch model')
+
+# Evaluate model
+#output = model(input)

--- a/NeuralNetwork/NeuralNetwork.py
+++ b/NeuralNetwork/NeuralNetwork.py
@@ -27,5 +27,6 @@ for i in range(0, 5):
     imshow(torch.from_numpy(trainloader.dataset.data[rnd]))
 
 # TESTING: Load neural network
+# Input and Output: 3 Channel Color (RGB), 1 Channel Depth
 model = torch.jit.load('./data/Pytorch_Jit_Model_Lucy.pt')
 print('Loaded pytorch model')

--- a/NeuralNetwork/NeuralNetwork.py
+++ b/NeuralNetwork/NeuralNetwork.py
@@ -25,3 +25,7 @@ for i in range(0, 5):
     rnd = random.randrange(0, len(trainloader.dataset))
     print(trainloader.dataset.classes[trainloader.dataset.targets[rnd]])
     imshow(torch.from_numpy(trainloader.dataset.data[rnd]))
+
+# TESTING: Load neural network
+model = torch.load('./data/Pytorch_Model_Lucy.pth')
+print('Loaded pytorch model')

--- a/NeuralNetwork/NeuralNetwork.py
+++ b/NeuralNetwork/NeuralNetwork.py
@@ -27,5 +27,5 @@ for i in range(0, 5):
     imshow(torch.from_numpy(trainloader.dataset.data[rnd]))
 
 # TESTING: Load neural network
-model = torch.load('./data/Pytorch_Model_Lucy.pth')
+model = torch.jit.load('./data/Pytorch_Jit_Model_Lucy.pt')
 print('Loaded pytorch model')

--- a/NeuralNetwork/NeuralNetwork.py
+++ b/NeuralNetwork/NeuralNetwork.py
@@ -6,10 +6,18 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 # Function to show an image from a tensor
-def ShowImage(image):
+def ShowImage(image, title='Figure'):
     npimage = image.detach().numpy()
-    npimage = np.transpose(npimage, axes=(1, 2, 0))
+
+    # Transpose for the correct shape
+    if npimage.shape[0] == 3:
+        npimage = np.transpose(npimage, axes=(1, 2, 0))
+    
+    if npimage.shape[0] == 2:
+        npimage = np.transpose(npimage)
+    
     plt.imshow(npimage)
+    plt.title(title)
     plt.show()
 
 # Load rendered images from .png files in folders "/data/Testset/GroundTruth/" and "/data/Testset/Input/"
@@ -19,17 +27,15 @@ testloader = torch.utils.data.DataLoader(testset, batch_size=3, shuffle=False, n
 # Show the images by using an iterator
 iterator = iter(testloader)
 
-print('Showing splats')
 splats = iterator.next()
-ShowImage(splats[0][0])
-#ShowImage(splats[0][1])
-#ShowImage(splats[0][2])
+#ShowImage(splats[0][0], 'Splats Color')
+#ShowImage(splats[0][1], 'Splats Depth')
+#ShowImage(splats[0][2], 'Splats Normals')
 
-print('Showing sparse points')
 sparsePoints = iterator.next()
-ShowImage(sparsePoints[0][0])
-#ShowImage(sparsePoints[0][1])
-#ShowImage(sparsePoints[0][2])
+#ShowImage(sparsePoints[0][0], 'Sparse Points Color')
+#ShowImage(sparsePoints[0][1], 'Sparse Points Depth')
+#ShowImage(sparsePoints[0][2], 'Sparse Points Normals')
 
 # Load and evaluate neural network
 model = torch.jit.load('./data/Pytorch_Jit_Model_Lucy.pt')
@@ -39,12 +45,25 @@ print('Loaded model')
 # Evaluate model with input from files
 # Input: 1 Channel Color (R, G or B), 1 Channel Depth
 # Output: 1 Channel Color, 1 Channel Depth, 1 Channel Visibility Mask
-input = sparsePoints[0].narrow(1, 0, 2)
+input = torch.zeros(1, 2, 1024, 1024)
+
+# First channel is color
+input[0][0] = sparsePoints[0][0][0]
+
+# Second channel is depth (average from RGB values)
+input[0][1] = torch.mean(sparsePoints[0][1], 0)
+
+# Show input images
+ShowImage(input[0][0], 'Input Color R')
+ShowImage(input[0][1], 'Input Depth')
+
+# Evaluate model on gpu
 input = input.cuda()
 output = model(input)
 print('Evaluated model')
 
 # Show output image from the neural network
-print('Showing output')
 output = output.cpu()
-ShowImage(output[0])
+ShowImage(output[0][0], 'Output Color R')
+ShowImage(output[0][1], 'Output Depth')
+ShowImage(output[0][2], 'Output Visibility Mask')

--- a/PointCloudEngine/Blending.hlsl
+++ b/PointCloudEngine/Blending.hlsl
@@ -1,4 +1,5 @@
 #include "ImageEffect.hlsl"
+#include "LightingConstantBuffer.hlsl"
 
 float4 PS(GS_INOUTPUT input) : SV_TARGET
 {
@@ -10,7 +11,7 @@ float4 PS(GS_INOUTPUT input) : SV_TARGET
 	if (color.a > 0)
 	{
 		// Remove the background color and alpha
-		color -= float4(0.5f, 0.5f, 0.5f, 0);
+		color -= float4(backgroundColor, 0);
 
 		// Divide by the sum of weights
 		color /= color.a;

--- a/PointCloudEngine/GroundTruthRenderer.cpp
+++ b/PointCloudEngine/GroundTruthRenderer.cpp
@@ -357,11 +357,11 @@ void PointCloudEngine::GroundTruthRenderer::DrawNeuralNetwork()
 					// Sum up to get the total dimensions of the input and output
 					if (channel.input)
 					{
-						inputDimensions++;
+						inputDimensions += channel.dimensions;
 					}
 					else
 					{
-						outputDimensions++;
+						outputDimensions += channel.dimensions;
 					}
 
 					modelChannels.push_back(channel);
@@ -525,14 +525,12 @@ void PointCloudEngine::GroundTruthRenderer::DrawNeuralNetwork()
 				std::vector<torch::jit::IValue> inputs;
 				inputs.push_back(inputTensor);
 
-				// Evaluate the model
-				// Input: 1 Channel Color (R, G or B), 1 Channel Depth
-				// Output: 1 Channel Color, 1 Channel Depth, 1 Channel Visibility Mask
+				// Evaluate the model, input and output channels are given in the model description
 				outputTensor = model.forward(inputs).toTensor();
 			}
 			catch (std::exception & e)
 			{
-				ERROR_MESSAGE(L"Could not evaluate Pytorch Jit Model.\nMake sure that the resolution in x and y is a multiple of 128!");
+				ERROR_MESSAGE(L"Could not evaluate Pytorch Jit Model.\nMake sure that the input dimensions and the resolution is correct!");
 			}
 		}
 

--- a/PointCloudEngine/GroundTruthRenderer.cpp
+++ b/PointCloudEngine/GroundTruthRenderer.cpp
@@ -288,7 +288,15 @@ void PointCloudEngine::GroundTruthRenderer::DrawNeuralNetwork()
 	// Load the neural network from file
 	if (torchDevice == NULL)
 	{
-		torchDevice = new torch::Device(torch::kCPU);
+		if (torch::cuda::is_available())
+		{
+			torchDevice = new torch::Device(at::kCUDA);
+		}
+		else
+		{
+			torchDevice = new torch::Device(at::kCPU);
+		}
+
 		std::wstring modelFilename = executableDirectory + L"\\NeuralNetwork.pt";
 
 		try
@@ -302,8 +310,10 @@ void PointCloudEngine::GroundTruthRenderer::DrawNeuralNetwork()
 	}
 
 	// Evaluate the network with random input
+	torch::Tensor input = torch::rand({ 1, 2, 128, 128 }, *torchDevice);
+
 	std::vector<torch::jit::IValue> inputs;
-	inputs.push_back(torch::rand({ 1, 2, 128, 128 }, *torchDevice));
+	inputs.push_back(input);
 
 	torch::Tensor output = model.forward(inputs).toTensor();
 

--- a/PointCloudEngine/GroundTruthRenderer.cpp
+++ b/PointCloudEngine/GroundTruthRenderer.cpp
@@ -537,10 +537,21 @@ void PointCloudEngine::GroundTruthRenderer::DrawNeuralNetwork()
 		// Fill a four channel color tensor with the output (required due to the texture memory layout)
 		torch::Tensor colorTensor = torch::zeros({ 4, settings->resolutionX, settings->resolutionY }, torch::dtype(torch::kHalf));
 
-		// TODO: Select individual output channels
-		for (int i = 0; i < min(outputDimensions, 4); i++)
+		// When a value is out of range this channel will be skipped
+		int colorToOutputChannels[] =
 		{
-			colorTensor[i] = outputTensor[0][i];
+			settings->neuralNetworkOutputRed,
+			settings->neuralNetworkOutputGreen,
+			settings->neuralNetworkOutputBlue
+		};
+
+		// Select individual output channels based on the values in the settings
+		for (int i = 0; i < 3; i++)
+		{
+			if (colorToOutputChannels[i] >= 0 && colorToOutputChannels[i] < outputDimensions)
+			{
+				colorTensor[i] = outputTensor[0][colorToOutputChannels[i]];
+			}
 		}
 
 		colorTensor = colorTensor.permute({ 1, 2, 0 }).contiguous().cpu();

--- a/PointCloudEngine/GroundTruthRenderer.cpp
+++ b/PointCloudEngine/GroundTruthRenderer.cpp
@@ -330,10 +330,10 @@ void PointCloudEngine::GroundTruthRenderer::DrawNeuralNetwork()
 		d3d11DevCon->Map(tensorTexture, 0, D3D11_MAP_READ, 0, &subresource);
 
 		// Convert the texture data to a tensor for the neural network
-		torch::Tensor input = torch::zeros({ 1, 2, 128, 128 }, torch::dtype(torch::kHalf));
+		torch::Tensor input = torch::zeros({ 1, 2, settings->resolutionX, settings->resolutionY }, torch::dtype(torch::kHalf));
 
 		// Copy the data from the texture to the tensor
-		memcpy(input.data_ptr(), subresource.pData, 2 * 2 * 128 * 128);
+		memcpy(input.data_ptr(), subresource.pData, 2 * 2 * settings->resolutionX * settings->resolutionY);
 
 		// Unmap the texture
 		d3d11DevCon->Unmap(tensorTexture, 0);
@@ -360,12 +360,12 @@ void PointCloudEngine::GroundTruthRenderer::DrawNeuralNetwork()
 		d3d11DevCon->Map(tensorTexture, 0, D3D11_MAP_WRITE, 0, &subresource);
 
 		// Copy the data from the texture to the tensor
-		memcpy(subresource.pData, output.data_ptr(), 2 * 2 * 128 * 128);
+		memcpy(subresource.pData, output.data_ptr(), 2 * 2 * settings->resolutionX * settings->resolutionY);
 
 		// Unmap the texture
 		d3d11DevCon->Unmap(tensorTexture, 0);
 
-		SaveWICTextureToFile(d3d11DevCon, tensorTexture, GUID_ContainerFormatPng, (executableDirectory + L"/Screenshots/" + std::to_wstring(time(0)) + L".png").c_str());
+		//SaveWICTextureToFile(d3d11DevCon, tensorTexture, GUID_ContainerFormatPng, (executableDirectory + L"/Screenshots/" + std::to_wstring(time(0)) + L".png").c_str());
 
 		SAFE_RELEASE(tensorTexture);
 	}

--- a/PointCloudEngine/GroundTruthRenderer.cpp
+++ b/PointCloudEngine/GroundTruthRenderer.cpp
@@ -587,6 +587,13 @@ void PointCloudEngine::GroundTruthRenderer::CalculateLosses()
 	// Render the loss input and store it in the self tensor
 	RenderToTensor(settings->lossCalculationSelf, selfTensor);
 
+	// Move tensors to gpu for faster computation
+	if (settings->useCUDA && torch::cuda::is_available())
+	{
+		selfTensor = selfTensor.cuda();
+		targetChannel->tensor = targetChannel->tensor.cuda();
+	}
+
 	// Calculate the losses
 	l1Loss = torch::l1_loss(selfTensor, targetChannel->tensor).cpu().data<float>()[0];
 	mseLoss = torch::mse_loss(selfTensor, targetChannel->tensor).cpu().data<float>()[0];

--- a/PointCloudEngine/GroundTruthRenderer.cpp
+++ b/PointCloudEngine/GroundTruthRenderer.cpp
@@ -365,7 +365,8 @@ void PointCloudEngine::GroundTruthRenderer::DrawNeuralNetwork()
 		// Unmap the texture
 		d3d11DevCon->Unmap(tensorTexture, 0);
 
-		//SaveWICTextureToFile(d3d11DevCon, tensorTexture, GUID_ContainerFormatPng, (executableDirectory + L"/Screenshots/" + std::to_wstring(time(0)) + L".png").c_str());
+		// Replace the backbuffer texture by the output
+		d3d11DevCon->CopyResource(backBufferTexture, tensorTexture);
 
 		SAFE_RELEASE(tensorTexture);
 	}

--- a/PointCloudEngine/GroundTruthRenderer.cpp
+++ b/PointCloudEngine/GroundTruthRenderer.cpp
@@ -307,6 +307,44 @@ void PointCloudEngine::GroundTruthRenderer::DrawNeuralNetwork()
 {
 	if (loadPytorchModel)
 	{
+		// Load .txt file storing neural network input and output channel descriptions
+		// Each entry consists of:
+		// - String: Name of the channel
+		// - Int: Dimension of channel
+		// - String: Identifying if the channel is input (inp) or output (tar)
+		// - String: Transformation keywords e.g. normalization
+		// - Int: Offset of this channel from the start channel
+		std::wifstream neuralNetworkDescriptionFile(executableDirectory + L"\\NeuralNetworkDescription.txt");
+
+		if (neuralNetworkDescriptionFile.is_open())
+		{
+			std::wstring line;
+			if (std::getline(neuralNetworkDescriptionFile, line))
+			{
+				std::wstring tmp = L"";
+
+				// Remove unwanted characters
+				for (int i = 0; i < line.length(); i++)
+				{
+					wchar_t c = line.at(i);
+					
+					if (c != ' ' && c != L'\'' && c != L'[' && c != L']')
+					{
+						tmp += c;
+					}
+				}
+
+				line = tmp;
+
+				std::vector<std::wstring> s = SplitString(line, L',');
+
+				for (int i = 0; i < s.size(); i++)
+				{
+					OutputDebugString((s[i] + L"\n").c_str());
+				}
+			}
+		}
+
 		// Only do this once
 		loadPytorchModel = false;
 
@@ -661,4 +699,24 @@ void PointCloudEngine::GroundTruthRenderer::GenerateWaypointDataset(HDF5File& hd
 			waypointLocation += settings->waypointStepSize;
 		}
 	}
+}
+
+std::vector<std::wstring> PointCloudEngine::GroundTruthRenderer::SplitString(std::wstring s, wchar_t delimiter)
+{
+	std::vector<std::wstring> output;
+	size_t index = s.find_first_of(delimiter);
+
+	while (index >= 0 && index <= s.length())
+	{
+		// Add the left side of the split to the output
+		output.push_back(s.substr(0, index));
+
+		// Continue looking for splits in the right side
+		s = s.substr(index + 1, s.length());
+		index = s.find_first_of(delimiter);
+	}
+
+	output.push_back(s);
+
+	return output;
 }

--- a/PointCloudEngine/GroundTruthRenderer.cpp
+++ b/PointCloudEngine/GroundTruthRenderer.cpp
@@ -423,11 +423,6 @@ void PointCloudEngine::GroundTruthRenderer::DrawNeuralNetwork()
 	}
 	else
 	{
-		// TODO: Call draw again in the corresponding view modes of the channels
-		// Copy data to the channel tensors
-		// Set input channels to these channels
-		// Evaluate and show result
-
 		// Copy the renderings to the tensors of the different input channels
 		for (auto it = modelChannels.begin(); it != modelChannels.end(); it++)
 		{
@@ -505,6 +500,12 @@ void PointCloudEngine::GroundTruthRenderer::DrawNeuralNetwork()
 				{
 					it->tensor = it->tensor.cuda();
 					inputTensor = inputTensor.cuda();
+				}
+
+				if (it->normalize)
+				{
+					// TODO: Normalize the tensor
+					// Right now this is not needed
 				}
 
 				// Convert to correct data type and shape for the input
@@ -719,13 +720,10 @@ void PointCloudEngine::GroundTruthRenderer::OutputTensorSize(torch::Tensor &tens
 
 void PointCloudEngine::GroundTruthRenderer::Redraw(bool present)
 {
-	// Clear the render target
+	// Clear the render target and depth/stencil view
 	d3d11DevCon->ClearRenderTargetView(renderTargetView, (float*)&settings->backgroundColor);
-
-	// Clear the depth/stencil view
 	d3d11DevCon->ClearDepthStencilView(depthStencilView, D3D11_CLEAR_DEPTH | D3D11_CLEAR_STENCIL, 1.0f, 0);
 
-	// Draw
 	Draw();
 
 	if (present)

--- a/PointCloudEngine/GroundTruthRenderer.cpp
+++ b/PointCloudEngine/GroundTruthRenderer.cpp
@@ -295,7 +295,7 @@ void PointCloudEngine::GroundTruthRenderer::DrawNeuralNetwork()
 		try
 		{
 			// Load the neural network from file
-			if (torch::cuda::is_available())
+			if (settings->useCUDA && torch::cuda::is_available())
 			{
 				model = torch::jit::load(std::string(modelFilename.begin(), modelFilename.end()), torch::Device(at::kCUDA));
 			}
@@ -360,7 +360,7 @@ void PointCloudEngine::GroundTruthRenderer::DrawNeuralNetwork()
 		d3d11DevCon->Unmap(depthTexture, 0);
 
 		// Move tensors to gpu for faster computation
-		if (torch::cuda::is_available())
+		if (settings->useCUDA && torch::cuda::is_available())
 		{
 			colorTensor = colorTensor.cuda();
 			depthTensor = depthTensor.cuda();

--- a/PointCloudEngine/GroundTruthRenderer.h
+++ b/PointCloudEngine/GroundTruthRenderer.h
@@ -102,8 +102,9 @@ namespace PointCloudEngine
 
 		void DrawNeuralNetwork();
 		void CalculateLosses();
-		void CopyBackbufferTextureToChannel(ModelChannel &channel);
-		void CopyDepthTextureToChannel(ModelChannel &channel);
+		void RenderToTensor(std::wstring renderMode, torch::Tensor& tensor);
+		void CopyBackbufferTextureToTensor(torch::Tensor &tensor);
+		void CopyDepthTextureToTensor(torch::Tensor &tensor);
 		void OutputTensorSize(torch::Tensor &tensor);
 		void Redraw(bool present);
 		void HDF5DrawDatasets(HDF5File& hdf5file, const UINT groupIndex);

--- a/PointCloudEngine/GroundTruthRenderer.h
+++ b/PointCloudEngine/GroundTruthRenderer.h
@@ -80,6 +80,7 @@ namespace PointCloudEngine
 		void HDF5DrawDatasets(HDF5File& hdf5file, const UINT groupIndex);
 		void GenerateSphereDataset(HDF5File& hdf5file);
 		void GenerateWaypointDataset(HDF5File& hdf5file);
+		std::vector<std::wstring> SplitString(std::wstring s, wchar_t delimiter);
     };
 }
 #endif

--- a/PointCloudEngine/GroundTruthRenderer.h
+++ b/PointCloudEngine/GroundTruthRenderer.h
@@ -66,12 +66,15 @@ namespace PointCloudEngine
 		torch::Tensor outputTensor;
 		ID3D11Texture2D* colorTexture = NULL;
 		ID3D11Texture2D* depthTexture = NULL;
+		float l1Loss, mseLoss, smoothL1Loss;
 
 		// Required to avoid memory overload with the forward function
 		// Since we don't use model.backward() it should be fine
 		torch::NoGradGuard noGradGuard;
 
 		void DrawNeuralNetwork();
+		void CalculateLosses();
+		void OutputTensorSize(torch::Tensor tensor);
 		void HDF5Draw();
 		void HDF5DrawDatasets(HDF5File& hdf5file, const UINT groupIndex);
 		void GenerateSphereDataset(HDF5File& hdf5file);

--- a/PointCloudEngine/GroundTruthRenderer.h
+++ b/PointCloudEngine/GroundTruthRenderer.h
@@ -58,7 +58,17 @@ namespace PointCloudEngine
 		};
 
 		// Pytorch Neural Network
-		torch::jit::script::Module* model = NULL;
+		bool loadPytorchModel = true;
+		torch::jit::script::Module model;
+		torch::Tensor colorTensor;
+		torch::Tensor depthTensor;
+		torch::Tensor inputTensor;
+		ID3D11Texture2D* colorTexture = NULL;
+		ID3D11Texture2D* depthTexture = NULL;
+
+		// Required to avoid memory overload with the forward function
+		// Since we don't use model.backward() it should be fine
+		//torch::NoGradGuard noGradGuard;
 
 		void DrawNeuralNetwork();
 		void HDF5Draw();

--- a/PointCloudEngine/GroundTruthRenderer.h
+++ b/PointCloudEngine/GroundTruthRenderer.h
@@ -59,6 +59,7 @@ namespace PointCloudEngine
 
 		// Pytorch Neural Network
 		bool loadPytorchModel = true;
+		bool validPytorchModel = false;
 		torch::jit::script::Module model;
 		torch::Tensor colorTensor;
 		torch::Tensor depthTensor;

--- a/PointCloudEngine/GroundTruthRenderer.h
+++ b/PointCloudEngine/GroundTruthRenderer.h
@@ -57,6 +57,11 @@ namespace PointCloudEngine
 			{ L"PointsSparseColor", L"PointsSparseNormal", L"PointsSparseNormalScreen", L"PointsSparseDepth" }
 		};
 
+		// Pytorch Neural Network
+		torch::Device *torchDevice = NULL;
+		torch::jit::script::Module model;
+
+		void DrawNeuralNetwork();
 		void HDF5Draw();
 		void HDF5DrawDatasets(HDF5File& hdf5file, const UINT groupIndex);
 		void GenerateSphereDataset(HDF5File& hdf5file);

--- a/PointCloudEngine/GroundTruthRenderer.h
+++ b/PointCloudEngine/GroundTruthRenderer.h
@@ -102,8 +102,8 @@ namespace PointCloudEngine
 
 		void DrawNeuralNetwork();
 		void CalculateLosses();
-		void CopyBackbufferTextureToTensor(torch::Tensor& tensor);
-		void CopyDepthTextureToTensor(torch::Tensor& tensor);
+		void CopyBackbufferTextureToChannel(ModelChannel &channel);
+		void CopyDepthTextureToChannel(ModelChannel &channel);
 		void OutputTensorSize(torch::Tensor &tensor);
 		void Redraw(bool present);
 		void HDF5DrawDatasets(HDF5File& hdf5file, const UINT groupIndex);

--- a/PointCloudEngine/GroundTruthRenderer.h
+++ b/PointCloudEngine/GroundTruthRenderer.h
@@ -58,8 +58,7 @@ namespace PointCloudEngine
 		};
 
 		// Pytorch Neural Network
-		torch::Device *torchDevice = NULL;
-		torch::jit::script::Module model;
+		torch::jit::script::Module* model = NULL;
 
 		void DrawNeuralNetwork();
 		void HDF5Draw();

--- a/PointCloudEngine/GroundTruthRenderer.h
+++ b/PointCloudEngine/GroundTruthRenderer.h
@@ -49,12 +49,28 @@ namespace PointCloudEngine
         ID3D11Buffer* vertexBuffer;		        // Holds vertex data
         ID3D11Buffer* constantBuffer;
 
-		std::wstring hdf5DatasetNames[4][4] =
+		// Maps from the name of the render mode to the view mode (x) and the shading mode (y)
+		std::map<std::wstring, XMUINT2> renderModes =
 		{
-			{ L"SplatsColor", L"SplatsNormal", L"SplatsNormalScreen", L"SplatsDepth" },
-			{ L"SplatsSparseColor", L"SplatsSparseNormal", L"SplatsSparseNormalScreen", L"SplatsSparseDepth" },
-			{ L"PointsColor", L"PointsNormal", L"PointsNormalScreen", L"PointsDepth" },
-			{ L"PointsSparseColor", L"PointsSparseNormal", L"PointsSparseNormalScreen", L"PointsSparseDepth" }
+			{ L"SplatsColor", XMUINT2(0, 0) },
+			{ L"SplatsDepth", XMUINT2(0, 1) },
+			{ L"SplatsNormal", XMUINT2(0, 2) },
+			{ L"SplatsNormalScreen", XMUINT2(0, 3) },
+
+			{ L"SplatsSparseColor", XMUINT2(1, 0) },
+			{ L"SplatsSparseDepth", XMUINT2(1, 1) },
+			{ L"SplatsSparseNormal", XMUINT2(1, 2) },
+			{ L"SplatsSparseNormalScreen", XMUINT2(1, 3) },
+
+			{ L"PointsColor", XMUINT2(2, 0) },
+			{ L"PointsDepth", XMUINT2(2, 1) },
+			{ L"PointsNormal", XMUINT2(2, 2) },
+			{ L"PointsNormalScreen", XMUINT2(2, 3) },
+
+			{ L"PointsSparseColor", XMUINT2(3, 0) },
+			{ L"PointsSparseDepth", XMUINT2(3, 1) },
+			{ L"PointsSparseNormal", XMUINT2(3, 2) },
+			{ L"PointsSparseNormalScreen", XMUINT2(3, 3) },
 		};
 
 		// Pytorch Neural Network

--- a/PointCloudEngine/GroundTruthRenderer.h
+++ b/PointCloudEngine/GroundTruthRenderer.h
@@ -63,12 +63,13 @@ namespace PointCloudEngine
 		torch::Tensor colorTensor;
 		torch::Tensor depthTensor;
 		torch::Tensor inputTensor;
+		torch::Tensor outputTensor;
 		ID3D11Texture2D* colorTexture = NULL;
 		ID3D11Texture2D* depthTexture = NULL;
 
 		// Required to avoid memory overload with the forward function
 		// Since we don't use model.backward() it should be fine
-		//torch::NoGradGuard noGradGuard;
+		torch::NoGradGuard noGradGuard;
 
 		void DrawNeuralNetwork();
 		void HDF5Draw();

--- a/PointCloudEngine/GroundTruthRenderer.h
+++ b/PointCloudEngine/GroundTruthRenderer.h
@@ -73,12 +73,23 @@ namespace PointCloudEngine
 			{ L"PointsSparseNormalScreen", XMUINT2(3, 3) },
 		};
 
+		// Used for parsing the model description file
+		struct ModelChannel
+		{
+			std::wstring name;
+			torch::Tensor tensor;
+			UINT dimensions;
+			UINT offset;
+			bool normalize;
+			bool input;
+		};
+
 		// Pytorch Neural Network
 		bool loadPytorchModel = true;
 		bool validPytorchModel = false;
 		torch::jit::script::Module model;
-		torch::Tensor colorTensor;
-		torch::Tensor depthTensor;
+		std::vector<ModelChannel> modelChannels;
+		UINT inputDimensions, outputDimensions;
 		torch::Tensor inputTensor;
 		torch::Tensor outputTensor;
 		ID3D11Texture2D* colorTexture = NULL;
@@ -91,8 +102,10 @@ namespace PointCloudEngine
 
 		void DrawNeuralNetwork();
 		void CalculateLosses();
-		void OutputTensorSize(torch::Tensor tensor);
-		void HDF5Draw();
+		void CopyBackbufferTextureToTensor(torch::Tensor& tensor);
+		void CopyDepthTextureToTensor(torch::Tensor& tensor);
+		void OutputTensorSize(torch::Tensor &tensor);
+		void Redraw(bool present);
 		void HDF5DrawDatasets(HDF5File& hdf5file, const UINT groupIndex);
 		void GenerateSphereDataset(HDF5File& hdf5file);
 		void GenerateWaypointDataset(HDF5File& hdf5file);

--- a/PointCloudEngine/LightingConstantBuffer.hlsl
+++ b/PointCloudEngine/LightingConstantBuffer.hlsl
@@ -9,7 +9,7 @@ cbuffer LightingConstantBuffer : register(b1)
 	float specular;
 //------------------------------------------------------------------------------ (16 byte boundary)
 	float specularExponent;
-	// 12 byte auto padding
+	float3 backgroundColor;
 //------------------------------------------------------------------------------ (16 byte boundary)
 };	// Total: 48 bytes with constant buffer packing rules
 

--- a/PointCloudEngine/Point.hlsl
+++ b/PointCloudEngine/Point.hlsl
@@ -19,6 +19,7 @@ void GS(point VS_OUTPUT input[1], inout PointStream<GS_POINT_OUTPUT> output)
 	element.position = mul(float4(input[0].position, 1), VP);
 	element.positionWorld = input[0].position;
 	element.normalScreen = normalize(mul(input[0].normal, VP));
+	element.normalScreen.z *= -1;
 	element.normal = input[0].normal;
 	element.color = input[0].color;
 

--- a/PointCloudEngine/PointCloudEngine.cpp
+++ b/PointCloudEngine/PointCloudEngine.cpp
@@ -605,8 +605,7 @@ void DrawScene()
     d3d11DevCon->OMSetRenderTargets(1, &renderTargetView, depthStencilView);	// 1 since there is only 1 view
 
 	// Clear out backbuffer to the updated color
-	float backgroundColor[4] = { 0.5f, 0.5f, 0.5f, 0 };
-	d3d11DevCon->ClearRenderTargetView(renderTargetView, backgroundColor);
+	d3d11DevCon->ClearRenderTargetView(renderTargetView, (float*)&settings->backgroundColor);
 	
 	// Refresh the depth/stencil view
 	d3d11DevCon->ClearDepthStencilView(depthStencilView, D3D11_CLEAR_DEPTH | D3D11_CLEAR_STENCIL, 1.0f, 0);
@@ -624,6 +623,7 @@ void DrawScene()
 	lightingConstantBufferData.diffuse = settings->diffuse;
 	lightingConstantBufferData.specular = settings->specular;
 	lightingConstantBufferData.specularExponent = settings->specularExponent;
+	lightingConstantBufferData.backgroundColor = (Vector3)settings->backgroundColor;
 
 	// Use a headlight or a constant light direction
 	if (settings->useHeadlight)

--- a/PointCloudEngine/PointCloudEngine.vcxproj
+++ b/PointCloudEngine/PointCloudEngine.vcxproj
@@ -238,12 +238,11 @@ copy /Y "C:\Program Files\HDF_Group\HDF5\1.10.5\bin\hdf5.dll" "$(OutDir)hdf5.dll
 copy /Y "C:\Program Files\HDF_Group\HDF5\1.10.5\bin\hdf5_cpp.dll" "$(OutDir)hdf5_cpp.dll"
 copy /Y "C:\Program Files\HDF_Group\HDF5\1.10.5\bin\szip.dll" "$(OutDir)szip.dll"
 copy /Y "C:\Program Files\HDF_Group\HDF5\1.10.5\bin\zlib.dll" "$(OutDir)zlib.dll"
-copy /Y "C:\ProgramData\Anaconda3\Lib\site-packages\torch\lib\torch.dll" "$(OutDir)torch.dll"
-copy /Y "C:\ProgramData\Anaconda3\Lib\site-packages\torch\lib\c10.dll" "$(OutDir)c10.dll"
-copy /Y "C:\ProgramData\Anaconda3\Lib\site-packages\torch\lib\c10_cuda.dll" "$(OutDir)c10_cuda.dll"
-copy /Y "C:\ProgramData\Anaconda3\Lib\site-packages\torch\lib\cudnn64_7.dll" "$(OutDir)cudnn64_7.dll"
+copy /Y "C:\ProgramData\Anaconda3\Lib\site-packages\torch\lib\*.dll" "$(OutDir)*.dll"
 copy /Y "C:\ProgramData\Anaconda3\Library\bin\nvToolsExt64_1.dll" "$(OutDir)nvToolsExt64_1.dll"
-copy /Y "C:\ProgramData\Anaconda3\Library\bin\libiomp5md.dll" "$(OutDir)libiomp5md.dll"</Command>
+copy /Y "C:\ProgramData\Anaconda3\Library\bin\libiomp5md.dll" "$(OutDir)libiomp5md.dll"
+copy /Y "C:\ProgramData\Anaconda3\Library\bin\cusparse64_100.dll" "$(OutDir)cusparse64_100.dll"
+copy /Y "C:\ProgramData\Anaconda3\Library\bin\curand64_100.dll" "$(OutDir)curand64_100.dll"</Command>
     </PostBuildEvent>
     <PreBuildEvent>
       <Command>

--- a/PointCloudEngine/PrecompiledHeader.h
+++ b/PointCloudEngine/PrecompiledHeader.h
@@ -1,5 +1,6 @@
 // Pytorch
 #include <torch/script.h>
+#include <torch/torch.h>
 
 #include <windows.h>
 #include <windowsx.h>

--- a/PointCloudEngine/Scene.cpp
+++ b/PointCloudEngine/Scene.cpp
@@ -77,7 +77,7 @@ void Scene::Update(Timer &timer)
 	// Toggle view mode depending on the renderer
 	if (Input::GetKeyDown(Keyboard::Enter))
 	{
-		settings->viewMode = (settings->viewMode + 1) % (settings->useOctree ? 3 : 4);
+		settings->viewMode = (settings->viewMode + 1) % (settings->useOctree ? 3 : 5);
 	}
 
 	// Toggle lighting with L

--- a/PointCloudEngine/Scene.cpp
+++ b/PointCloudEngine/Scene.cpp
@@ -192,10 +192,13 @@ void Scene::Update(Timer &timer)
         timeSinceLoadFile += dt;
     }
 
-    // Increase input speed when pressing shift
+    // Increase input speed when pressing shift and one of the other keys
     if (Input::GetKey(Keyboard::LeftShift))
     {
-        inputSpeed += 20 * dt;
+		if (Input::GetKey(Keyboard::W) || Input::GetKey(Keyboard::A) || Input::GetKey(Keyboard::S) || Input::GetKey(Keyboard::D) || Input::GetKey(Keyboard::Q) || Input::GetKey(Keyboard::E))
+		{
+			inputSpeed += 20 * dt;
+		}
     }
     else
     {

--- a/PointCloudEngine/Settings.cpp
+++ b/PointCloudEngine/Settings.cpp
@@ -63,6 +63,9 @@ PointCloudEngine::Settings::Settings()
 		// Parse neural network parameters
 		TryParse(NAMEOF(useCUDA), useCUDA);
 		TryParse(NAMEOF(neuralNetworkScreenArea), neuralNetworkScreenArea);
+		TryParse(NAMEOF(neuralNetworkOutputRed), neuralNetworkOutputRed);
+		TryParse(NAMEOF(neuralNetworkOutputGreen), neuralNetworkOutputGreen);
+		TryParse(NAMEOF(neuralNetworkOutputBlue), neuralNetworkOutputBlue);
 
 		// Parse HDF5 dataset generation parameters
 		TryParse(NAMEOF(waypointStepSize), waypointStepSize);
@@ -136,6 +139,9 @@ PointCloudEngine::Settings::~Settings()
 	settingsFile << L"# Neural Network Parameters" << std::endl;
 	settingsFile << NAMEOF(useCUDA) << L"=" << useCUDA << std::endl;
 	settingsFile << NAMEOF(neuralNetworkScreenArea) << L"=" << neuralNetworkScreenArea << std::endl;
+	settingsFile << NAMEOF(neuralNetworkOutputRed) << L"=" << neuralNetworkOutputRed << std::endl;
+	settingsFile << NAMEOF(neuralNetworkOutputGreen) << L"=" << neuralNetworkOutputGreen << std::endl;
+	settingsFile << NAMEOF(neuralNetworkOutputBlue) << L"=" << neuralNetworkOutputBlue << std::endl;
 	settingsFile << std::endl;
 
 	settingsFile << L"# HDF5 Dataset Generation Parameters" << std::endl;

--- a/PointCloudEngine/Settings.cpp
+++ b/PointCloudEngine/Settings.cpp
@@ -59,6 +59,9 @@ PointCloudEngine::Settings::Settings()
 		TryParse(NAMEOF(density), density);
 		TryParse(NAMEOF(sparseSamplingRate), sparseSamplingRate);
 
+		// Parse neural network parameters
+		TryParse(NAMEOF(useCUDA), useCUDA);
+
 		// Parse HDF5 dataset generation parameters
 		TryParse(NAMEOF(waypointStepSize), waypointStepSize);
 		TryParse(NAMEOF(waypointPreviewStepSize), waypointPreviewStepSize);
@@ -125,6 +128,10 @@ PointCloudEngine::Settings::~Settings()
 	settingsFile << L"# Ground Truth Parameters" << std::endl;
 	settingsFile << NAMEOF(density) << L"=" << density << std::endl;
 	settingsFile << NAMEOF(sparseSamplingRate) << L"=" << sparseSamplingRate << std::endl;
+	settingsFile << std::endl;
+
+	settingsFile << L"# Neural Network Parameters" << std::endl;
+	settingsFile << NAMEOF(useCUDA) << L"=" << useCUDA << std::endl;
 	settingsFile << std::endl;
 
 	settingsFile << L"# HDF5 Dataset Generation Parameters" << std::endl;

--- a/PointCloudEngine/Settings.cpp
+++ b/PointCloudEngine/Settings.cpp
@@ -27,6 +27,7 @@ PointCloudEngine::Settings::Settings()
         }
 
 		// Parse rendering parameters
+		TryParse(NAMEOF(backgroundColor), backgroundColor);
 		TryParse(NAMEOF(fovAngleY), fovAngleY);
 		TryParse(NAMEOF(nearZ), nearZ);
 		TryParse(NAMEOF(farZ), farZ);
@@ -93,6 +94,7 @@ PointCloudEngine::Settings::~Settings()
 	settingsFile << std::endl;
 
     settingsFile << L"# Rendering Parameters" << std::endl;
+	settingsFile << NAMEOF(backgroundColor) << L"=" << ToString(backgroundColor) << std::endl;
     settingsFile << NAMEOF(fovAngleY) << L"=" << fovAngleY << std::endl;
     settingsFile << NAMEOF(nearZ) << L"=" << nearZ << std::endl;
     settingsFile << NAMEOF(farZ) << L"=" << farZ << std::endl;
@@ -167,6 +169,11 @@ std::wstring PointCloudEngine::Settings::ToString(Vector3 v)
 	return L"(" + std::to_wstring(v.x) + L"," + std::to_wstring(v.y) + L"," + std::to_wstring(v.z) + L")";
 }
 
+std::wstring PointCloudEngine::Settings::ToString(Vector4 v)
+{
+	return L"(" + std::to_wstring(v.x) + L"," + std::to_wstring(v.y) + L"," + std::to_wstring(v.z) + L"," + std::to_wstring(v.w) + L")";
+}
+
 Vector3 PointCloudEngine::Settings::ToVector3(std::wstring s)
 {
 	// Remove brackets
@@ -179,6 +186,22 @@ Vector3 PointCloudEngine::Settings::ToVector3(std::wstring s)
 	std::wstring z = s.substr(y.length() + 1, s.length());
 	
 	return Vector3(std::stof(x), std::stof(y), std::stof(z));
+}
+
+Vector4 PointCloudEngine::Settings::ToVector4(std::wstring s)
+{
+	// Remove brackets
+	s = s.substr(1, s.length() - 1);
+
+	// Parse the string into seperate x,y,z,w strings
+	std::wstring x = s.substr(0, s.find(L','));
+	s = s.substr(x.length() + 1, s.length());
+	std::wstring y = s.substr(0, s.find(L','));
+	s = s.substr(y.length() + 1, s.length());
+	std::wstring z = s.substr(0, s.find(L','));
+	std::wstring w = s.substr(z.length() + 1, s.length());
+
+	return Vector4(std::stof(x), std::stof(y), std::stof(z), std::stof(w));
 }
 
 void PointCloudEngine::Settings::TryParse(std::wstring parameterName, float& outParameterValue)
@@ -218,6 +241,14 @@ void PointCloudEngine::Settings::TryParse(std::wstring parameterName, Vector3& o
 	if (settingsMap.find(parameterName) != settingsMap.end())
 	{
 		outParameterValue = ToVector3(settingsMap[parameterName]);
+	}
+}
+
+void PointCloudEngine::Settings::TryParse(std::wstring parameterName, Vector4& outParameterValue)
+{
+	if (settingsMap.find(parameterName) != settingsMap.end())
+	{
+		outParameterValue = ToVector4(settingsMap[parameterName]);
 	}
 }
 

--- a/PointCloudEngine/Settings.cpp
+++ b/PointCloudEngine/Settings.cpp
@@ -62,7 +62,7 @@ PointCloudEngine::Settings::Settings()
 
 		// Parse neural network parameters
 		TryParse(NAMEOF(useCUDA), useCUDA);
-		TryParse(NAMEOF(calculateLosses), calculateLosses);
+		TryParse(NAMEOF(neuralNetworkScreenArea), neuralNetworkScreenArea);
 
 		// Parse HDF5 dataset generation parameters
 		TryParse(NAMEOF(waypointStepSize), waypointStepSize);
@@ -135,7 +135,7 @@ PointCloudEngine::Settings::~Settings()
 
 	settingsFile << L"# Neural Network Parameters" << std::endl;
 	settingsFile << NAMEOF(useCUDA) << L"=" << useCUDA << std::endl;
-	settingsFile << NAMEOF(calculateLosses) << L"=" << calculateLosses << std::endl;
+	settingsFile << NAMEOF(neuralNetworkScreenArea) << L"=" << neuralNetworkScreenArea << std::endl;
 	settingsFile << std::endl;
 
 	settingsFile << L"# HDF5 Dataset Generation Parameters" << std::endl;

--- a/PointCloudEngine/Settings.cpp
+++ b/PointCloudEngine/Settings.cpp
@@ -61,6 +61,7 @@ PointCloudEngine::Settings::Settings()
 
 		// Parse neural network parameters
 		TryParse(NAMEOF(useCUDA), useCUDA);
+		TryParse(NAMEOF(calculateLosses), calculateLosses);
 
 		// Parse HDF5 dataset generation parameters
 		TryParse(NAMEOF(waypointStepSize), waypointStepSize);
@@ -132,6 +133,7 @@ PointCloudEngine::Settings::~Settings()
 
 	settingsFile << L"# Neural Network Parameters" << std::endl;
 	settingsFile << NAMEOF(useCUDA) << L"=" << useCUDA << std::endl;
+	settingsFile << NAMEOF(calculateLosses) << L"=" << calculateLosses << std::endl;
 	settingsFile << std::endl;
 
 	settingsFile << L"# HDF5 Dataset Generation Parameters" << std::endl;

--- a/PointCloudEngine/Settings.cpp
+++ b/PointCloudEngine/Settings.cpp
@@ -66,6 +66,8 @@ PointCloudEngine::Settings::Settings()
 		TryParse(NAMEOF(neuralNetworkOutputRed), neuralNetworkOutputRed);
 		TryParse(NAMEOF(neuralNetworkOutputGreen), neuralNetworkOutputGreen);
 		TryParse(NAMEOF(neuralNetworkOutputBlue), neuralNetworkOutputBlue);
+		TryParse(NAMEOF(lossCalculationSelf), lossCalculationSelf);
+		TryParse(NAMEOF(lossCalculationTarget), lossCalculationTarget);
 
 		// Parse HDF5 dataset generation parameters
 		TryParse(NAMEOF(waypointStepSize), waypointStepSize);
@@ -142,6 +144,8 @@ PointCloudEngine::Settings::~Settings()
 	settingsFile << NAMEOF(neuralNetworkOutputRed) << L"=" << neuralNetworkOutputRed << std::endl;
 	settingsFile << NAMEOF(neuralNetworkOutputGreen) << L"=" << neuralNetworkOutputGreen << std::endl;
 	settingsFile << NAMEOF(neuralNetworkOutputBlue) << L"=" << neuralNetworkOutputBlue << std::endl;
+	settingsFile << NAMEOF(lossCalculationSelf) << L"=" << lossCalculationSelf << std::endl;
+	settingsFile << NAMEOF(lossCalculationTarget) << L"=" << lossCalculationTarget << std::endl;
 	settingsFile << std::endl;
 
 	settingsFile << L"# HDF5 Dataset Generation Parameters" << std::endl;

--- a/PointCloudEngine/Settings.h
+++ b/PointCloudEngine/Settings.h
@@ -13,6 +13,7 @@ namespace PointCloudEngine
         ~Settings();
 
         // Rendering parameters default values
+		Vector4 backgroundColor = Vector4(0.5f, 0.5f, 0.5f, 0);
         float fovAngleY = 0.4f * XM_PI;
         float nearZ = 0.1f;
         float farZ = 1000.0f;
@@ -69,7 +70,9 @@ namespace PointCloudEngine
         float scrollSensitivity = 0.5f;
 
 		std::wstring ToString(Vector3 v);
+		std::wstring ToString(Vector4 v);
 		Vector3 ToVector3(std::wstring s);
+		Vector4 ToVector4(std::wstring s);
 
 	private:
 		std::map<std::wstring, std::wstring> settingsMap;
@@ -79,6 +82,7 @@ namespace PointCloudEngine
 		void TryParse(std::wstring parameterName, UINT& outParameterValue);
 		void TryParse(std::wstring parameterName, bool& outParameterValue);
 		void TryParse(std::wstring parameterName, Vector3& outParameterValue);
+		void TryParse(std::wstring parameterName, Vector4& outParameterValue);
 		void TryParse(std::wstring parameterName, std::wstring& outParameterValue);
     };
 }

--- a/PointCloudEngine/Settings.h
+++ b/PointCloudEngine/Settings.h
@@ -48,7 +48,7 @@ namespace PointCloudEngine
 
 		// Neural Network parameters
 		bool useCUDA = true;
-		bool calculateLosses = true;
+		float neuralNetworkScreenArea = 0.5f;
 
 		// HDF5 dataset generation parameters
 		float waypointStepSize = 0.5f;

--- a/PointCloudEngine/Settings.h
+++ b/PointCloudEngine/Settings.h
@@ -49,6 +49,9 @@ namespace PointCloudEngine
 		// Neural Network parameters
 		bool useCUDA = true;
 		float neuralNetworkScreenArea = 0.5f;
+		int neuralNetworkOutputRed = 0;
+		int neuralNetworkOutputGreen = 1;
+		int neuralNetworkOutputBlue = 2;
 
 		// HDF5 dataset generation parameters
 		float waypointStepSize = 0.5f;

--- a/PointCloudEngine/Settings.h
+++ b/PointCloudEngine/Settings.h
@@ -52,6 +52,8 @@ namespace PointCloudEngine
 		int neuralNetworkOutputRed = 0;
 		int neuralNetworkOutputGreen = 1;
 		int neuralNetworkOutputBlue = 2;
+		std::wstring lossCalculationSelf = L"SplatsColor";
+		std::wstring lossCalculationTarget = L"SplatsColor";
 
 		// HDF5 dataset generation parameters
 		float waypointStepSize = 0.5f;

--- a/PointCloudEngine/Settings.h
+++ b/PointCloudEngine/Settings.h
@@ -45,6 +45,9 @@ namespace PointCloudEngine
 		float density = 1.0f;
 		float sparseSamplingRate = 0.01f;
 
+		// Neural Network parameters
+		bool useCUDA = true;
+
 		// HDF5 dataset generation parameters
 		float waypointStepSize = 0.5f;
 		float waypointPreviewStepSize = 0.1f;

--- a/PointCloudEngine/Settings.h
+++ b/PointCloudEngine/Settings.h
@@ -47,6 +47,7 @@ namespace PointCloudEngine
 
 		// Neural Network parameters
 		bool useCUDA = true;
+		bool calculateLosses = true;
 
 		// HDF5 dataset generation parameters
 		float waypointStepSize = 0.5f;

--- a/PointCloudEngine/Settings.h
+++ b/PointCloudEngine/Settings.h
@@ -13,7 +13,7 @@ namespace PointCloudEngine
         ~Settings();
 
         // Rendering parameters default values
-		Vector4 backgroundColor = Vector4(0.5f, 0.5f, 0.5f, 0);
+		Vector4 backgroundColor = Vector4(0, 0, 0, 0);
         float fovAngleY = 0.4f * XM_PI;
         float nearZ = 0.1f;
         float farZ = 1000.0f;

--- a/PointCloudEngine/SplatBlending.hlsl
+++ b/PointCloudEngine/SplatBlending.hlsl
@@ -42,6 +42,7 @@ void SplatBlendingGS(float3 worldPosition, float3 worldNormal, float3 color, flo
 	GS_SPLAT_OUTPUT element;
 	element.positionCenter = worldPosition;
 	element.normalScreen = normalize(mul(worldNormal, VP));
+	element.normalScreen.z *= -1;
 	element.normal = worldNormal;
 	element.color = color;
 	element.radius = length(up);

--- a/PointCloudEngine/Structures.h
+++ b/PointCloudEngine/Structures.h
@@ -209,7 +209,7 @@ namespace PointCloudEngine
 		float diffuse;
 		float specular;
 		float specularExponent;
-		float padding[3];
+		Vector3 backgroundColor;
 	};
 }
 


### PR DESCRIPTION
- Added neural network view mode to the GroundTruthRenderer
- Loads a pytorch jit model (NeuralNetwork.pt) and a channel description file (NeuralNetworkDescription.txt)
- Evaluates the model and renders the output
- Output channels can be changed in the settings
- Loss functions are performed and can be compared in real time
- Channels for loss functions can be set in the settings
- UP/DOWN keys increase or decrease the self/target screen area